### PR TITLE
Prioritise paid developer account over free

### DIFF
--- a/AltStore/Operations/AuthenticationOperation.swift
+++ b/AltStore/Operations/AuthenticationOperation.swift
@@ -432,11 +432,11 @@ private extension AuthenticationOperation
     {
         func selectTeam(from teams: [ALTTeam])
         {
-            if let team = teams.first(where: { $0.type == .free })
+            if let team = teams.first(where: { $0.type == .individual })
             {
                 return completionHandler(.success(team))
             }
-            else if let team = teams.first(where: { $0.type == .individual })
+            else if let team = teams.first(where: { $0.type == .free })
             {
                 return completionHandler(.success(team))
             }


### PR DESCRIPTION
If an account has both a free and paid developer account active concurrently, then the free account is preferred. Prefer the paid account for a longer signing period